### PR TITLE
feat(cmd): add reset-tests command to delete test entries by operationId

### DIFF
--- a/cmd/reset_tests.go
+++ b/cmd/reset_tests.go
@@ -1,0 +1,215 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+// GenLock represents the structure of the gen.lock file
+type GenLock struct {
+	LockVersion    string            `yaml:"lockVersion"`
+	ID             string            `yaml:"id"`
+	GeneratedTests map[string]string `yaml:"generatedTests"`
+}
+
+// ArazzoWorkflow represents a workflow in the Arazzo file
+type ArazzoWorkflow struct {
+	WorkflowID string `yaml:"workflowId"`
+	Steps      []struct {
+		StepID      string `yaml:"stepId"`
+		OperationID string `yaml:"operationId"`
+		// We'll preserve other fields as raw YAML
+	} `yaml:"steps"`
+	// Preserve all other fields
+	ExtraData map[string]interface{} `yaml:",inline"`
+}
+
+// ArazzoFile represents the structure of the test.arazzo.yaml file
+type ArazzoFile struct {
+	Arazzo             string                   `yaml:"arazzo"`
+	Info               map[string]interface{}   `yaml:"info"`
+	SourceDescriptions []map[string]interface{} `yaml:"sourceDescriptions"`
+	Workflows          []map[string]interface{} `yaml:"workflows"`
+}
+
+var resetTestsCmd = &cobra.Command{
+	Use:   "reset-tests",
+	Short: "Reset test entries for specified operation IDs",
+	Long: `Delete test entries from both gen.lock and test.arazzo.yaml files
+for the specified operation IDs. This is helpful to allow a subsequent
+'speakeasy run' to regenerate the test files (e.g. if you have new fields /
+equirements in your upstream OpenAPI spec)`,
+	RunE: runResetTests,
+}
+
+var operationIDs []string
+
+func init() {
+	rootCmd.AddCommand(resetTestsCmd)
+	resetTestsCmd.Flags().StringArrayVar(&operationIDs, "operation-id", []string{}, "Operation ID to reset (can be specified multiple times)")
+	_ = resetTestsCmd.MarkFlagRequired("operation-id")
+}
+
+func runResetTests(cmd *cobra.Command, args []string) error {
+	if len(operationIDs) == 0 {
+		return fmt.Errorf("at least one operation ID must be specified")
+	}
+
+	// Convert operation IDs to a map for faster lookup
+	operationIDSet := make(map[string]bool)
+	for _, id := range operationIDs {
+		operationIDSet[id] = true
+	}
+
+	// Process gen.lock file
+	genLockPath := ".speakeasy/gen.lock"
+	if err := processGenLock(genLockPath, operationIDSet); err != nil {
+		return fmt.Errorf("failed to process gen.lock: %w", err)
+	}
+
+	// Process test.arazzo.yaml file
+	arazzoPath := ".speakeasy/test.arazzo.yaml"
+	if err := processArazzoFile(arazzoPath, operationIDSet); err != nil {
+		return fmt.Errorf("failed to process test.arazzo.yaml: %w", err)
+	}
+
+	fmt.Printf("Successfully deleted test entries for operation IDs: %v\n", operationIDs)
+	return nil
+}
+
+func processGenLock(filePath string, operationIDSet map[string]bool) error {
+	// Check if file exists
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		fmt.Printf("Warning: %s does not exist, skipping\n", filePath)
+		return nil
+	}
+
+	// Read the file
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %w", filePath, err)
+	}
+
+	// Parse YAML
+	var genLock GenLock
+	if err := yaml.Unmarshal(data, &genLock); err != nil {
+		return fmt.Errorf("failed to parse %s: %w", filePath, err)
+	}
+
+	// Remove entries for specified operation IDs
+	deletedCount := 0
+	for operationID := range operationIDSet {
+		if _, exists := genLock.GeneratedTests[operationID]; exists {
+			delete(genLock.GeneratedTests, operationID)
+			deletedCount++
+		}
+	}
+
+	if deletedCount == 0 {
+		fmt.Printf("No entries found to delete in %s\n", filePath)
+		return nil
+	}
+
+	// Write back to file
+	updatedData, err := yaml.Marshal(&genLock)
+	if err != nil {
+		return fmt.Errorf("failed to marshal updated gen.lock: %w", err)
+	}
+
+	// Ensure directory exists
+	if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	if err := os.WriteFile(filePath, updatedData, 0o644); err != nil {
+		return fmt.Errorf("failed to write %s: %w", filePath, err)
+	}
+
+	fmt.Printf("Deleted %d entries from %s\n", deletedCount, filePath)
+	return nil
+}
+
+func processArazzoFile(filePath string, operationIDSet map[string]bool) error {
+	// Check if file exists
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		fmt.Printf("Warning: %s does not exist, skipping\n", filePath)
+		return nil
+	}
+
+	// Read the file
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %w", filePath, err)
+	}
+
+	// Parse YAML as generic interface to preserve structure
+	var arazzoFile map[string]interface{}
+	if err := yaml.Unmarshal(data, &arazzoFile); err != nil {
+		return fmt.Errorf("failed to parse %s: %w", filePath, err)
+	}
+
+	// Process workflows
+	workflows, ok := arazzoFile["workflows"].([]interface{})
+	if !ok {
+		fmt.Printf("No workflows found in %s\n", filePath)
+		return nil
+	}
+
+	var filteredWorkflows []interface{}
+	deletedCount := 0
+
+	for _, workflow := range workflows {
+		workflowMap, ok := workflow.(map[string]interface{})
+		if !ok {
+			// Keep workflows that we can't parse
+			filteredWorkflows = append(filteredWorkflows, workflow)
+			continue
+		}
+
+		workflowID, ok := workflowMap["workflowId"].(string)
+		if !ok {
+			// Keep workflows without workflowId
+			filteredWorkflows = append(filteredWorkflows, workflow)
+			continue
+		}
+
+		// If this workflowId is in our set of operation IDs to delete, skip it
+		if operationIDSet[workflowID] {
+			deletedCount++
+			continue
+		}
+
+		// Keep this workflow
+		filteredWorkflows = append(filteredWorkflows, workflow)
+	}
+
+	if deletedCount == 0 {
+		fmt.Printf("No workflows found to delete in %s\n", filePath)
+		return nil
+	}
+
+	// Update the workflows in the file
+	arazzoFile["workflows"] = filteredWorkflows
+
+	// Write back to file
+	updatedData, err := yaml.Marshal(arazzoFile)
+	if err != nil {
+		return fmt.Errorf("failed to marshal updated arazzo file: %w", err)
+	}
+
+	// Ensure directory exists
+	if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	if err := os.WriteFile(filePath, updatedData, 0o644); err != nil {
+		return fmt.Errorf("failed to write %s: %w", filePath, err)
+	}
+
+	fmt.Printf("Deleted %d workflows from %s\n", deletedCount, filePath)
+	return nil
+}

--- a/cmd/reset_tests_test.go
+++ b/cmd/reset_tests_test.go
@@ -1,0 +1,245 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestResetTestsCommand(t *testing.T) {
+	// Create a temporary directory for test files
+	tempDir := t.TempDir()
+	speakeasyDir := filepath.Join(tempDir, ".speakeasy")
+	err := os.MkdirAll(speakeasyDir, 0o755)
+	require.NoError(t, err)
+
+	// Change to temp directory
+	originalDir, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, os.Chdir(originalDir))
+	}()
+	err = os.Chdir(tempDir)
+	require.NoError(t, err)
+
+	// Create test gen.lock file
+	genLockContent := `lockVersion: 2.0.0
+id: 3e3290ca-0ee8-4981-b1bc-14536048fa63
+generatedTests:
+  activity: "2025-04-28T22:05:12+01:00"
+  feedback: "2025-04-28T22:05:12+01:00"
+  createannouncement: "2025-04-28T22:05:12+01:00"
+  createdraftannouncement: "2025-04-28T22:05:12+01:00"
+  deleteannouncement: "2025-04-28T22:05:12+01:00"
+  deletedraftannouncement: "2025-04-28T22:05:12+01:00"
+  getannouncement: "2025-04-28T22:05:12+01:00"
+  getdraftannouncement: "2025-04-28T22:05:12+01:00"
+`
+	err = os.WriteFile(filepath.Join(speakeasyDir, "gen.lock"), []byte(genLockContent), 0o644)
+	require.NoError(t, err)
+
+	// Create test arazzo file
+	arazzoContent := `arazzo: 1.0.1
+info:
+  title: Test Suite
+  summary: Created from /Users/da/code/misc/api-client-python/.speakeasy/temp/665c0f/openapi/bundle/openapi.yaml
+  version: 0.0.1
+sourceDescriptions:
+  - name: /Users/da/code/misc/api-client-python/.speakeasy/temp/665c0f/openapi/bundle/openapi.yaml
+    url: https://TBD.com
+    type: openapi
+workflows:
+  - workflowId: activity
+    steps:
+      - stepId: test
+        operationId: activity
+        requestBody:
+          contentType: application/json
+          payload:
+            events:
+              - action: HISTORICAL_VIEW
+                timestamp: "2000-01-23T04:56:07.000Z"
+                url: https://example.com/
+        successCriteria:
+          - condition: $statusCode == 200
+    x-speakeasy-test-group: client_activity
+  - workflowId: feedback
+    steps:
+      - stepId: test
+        operationId: feedback
+        requestBody:
+          contentType: application/json
+          payload:
+            message: "test feedback"
+        successCriteria:
+          - condition: $statusCode == 200
+    x-speakeasy-test-group: client_feedback
+`
+	err = os.WriteFile(filepath.Join(speakeasyDir, "test.arazzo.yaml"), []byte(arazzoContent), 0o644)
+	require.NoError(t, err)
+
+	// Set up the command with operation IDs to delete
+	operationIDs = []string{"activity", "feedback"}
+
+	// Run the delete tests command
+	err = runResetTests(resetTestsCmd, []string{})
+	require.NoError(t, err)
+
+	// Verify gen.lock was updated correctly
+	genLockData, err := os.ReadFile(filepath.Join(speakeasyDir, "gen.lock"))
+	require.NoError(t, err)
+
+	var updatedGenLock GenLock
+	err = yaml.Unmarshal(genLockData, &updatedGenLock)
+	require.NoError(t, err)
+
+	// Should not contain activity or feedback
+	assert.NotContains(t, updatedGenLock.GeneratedTests, "activity")
+	assert.NotContains(t, updatedGenLock.GeneratedTests, "feedback")
+	// Should still contain other entries
+	assert.Contains(t, updatedGenLock.GeneratedTests, "createannouncement")
+	assert.Contains(t, updatedGenLock.GeneratedTests, "getannouncement")
+
+	// Verify arazzo file was updated correctly
+	arazzoData, err := os.ReadFile(filepath.Join(speakeasyDir, "test.arazzo.yaml"))
+	require.NoError(t, err)
+
+	var updatedArazzo map[string]interface{}
+	err = yaml.Unmarshal(arazzoData, &updatedArazzo)
+	require.NoError(t, err)
+
+	workflows, ok := updatedArazzo["workflows"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, workflows, 0, "All workflows should be deleted since both activity and feedback were specified")
+}
+
+func TestResetTestsCommandPartialDelete(t *testing.T) {
+	// Create a temporary directory for test files
+	tempDir := t.TempDir()
+	speakeasyDir := filepath.Join(tempDir, ".speakeasy")
+	err := os.MkdirAll(speakeasyDir, 0o755)
+	require.NoError(t, err)
+
+	// Change to temp directory
+	originalDir, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, os.Chdir(originalDir))
+	}()
+	err = os.Chdir(tempDir)
+	require.NoError(t, err)
+
+	// Create test gen.lock file
+	genLockContent := `lockVersion: 2.0.0
+id: 3e3290ca-0ee8-4981-b1bc-14536048fa63
+generatedTests:
+  activity: "2025-04-28T22:05:12+01:00"
+  feedback: "2025-04-28T22:05:12+01:00"
+  createannouncement: "2025-04-28T22:05:12+01:00"
+`
+	err = os.WriteFile(filepath.Join(speakeasyDir, "gen.lock"), []byte(genLockContent), 0o644)
+	require.NoError(t, err)
+
+	// Create test arazzo file with three workflows
+	arazzoContent := `arazzo: 1.0.1
+info:
+  title: Test Suite
+  version: 0.0.1
+workflows:
+  - workflowId: activity
+    steps:
+      - stepId: test
+        operationId: activity
+  - workflowId: feedback
+    steps:
+      - stepId: test
+        operationId: feedback
+  - workflowId: createannouncement
+    steps:
+      - stepId: test
+        operationId: createannouncement
+`
+	err = os.WriteFile(filepath.Join(speakeasyDir, "test.arazzo.yaml"), []byte(arazzoContent), 0o644)
+	require.NoError(t, err)
+
+	// Set up the command with only one operation ID to delete
+	operationIDs = []string{"activity"}
+
+	// Run the delete tests command
+	err = runResetTests(resetTestsCmd, []string{})
+	require.NoError(t, err)
+
+	// Verify gen.lock was updated correctly
+	genLockData, err := os.ReadFile(filepath.Join(speakeasyDir, "gen.lock"))
+	require.NoError(t, err)
+
+	var updatedGenLock GenLock
+	err = yaml.Unmarshal(genLockData, &updatedGenLock)
+	require.NoError(t, err)
+
+	// Should not contain activity
+	assert.NotContains(t, updatedGenLock.GeneratedTests, "activity")
+	// Should still contain feedback and createannouncement
+	assert.Contains(t, updatedGenLock.GeneratedTests, "feedback")
+	assert.Contains(t, updatedGenLock.GeneratedTests, "createannouncement")
+
+	// Verify arazzo file was updated correctly
+	arazzoData, err := os.ReadFile(filepath.Join(speakeasyDir, "test.arazzo.yaml"))
+	require.NoError(t, err)
+
+	var updatedArazzo map[string]interface{}
+	err = yaml.Unmarshal(arazzoData, &updatedArazzo)
+	require.NoError(t, err)
+
+	workflows, ok := updatedArazzo["workflows"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, workflows, 2, "Should have 2 workflows remaining")
+
+	// Check that the remaining workflows are feedback and createannouncement
+	remainingWorkflowIDs := make([]string, 0)
+	for _, workflow := range workflows {
+		workflowMap, ok := workflow.(map[string]interface{})
+		require.True(t, ok)
+		workflowID, ok := workflowMap["workflowId"].(string)
+		require.True(t, ok)
+		remainingWorkflowIDs = append(remainingWorkflowIDs, workflowID)
+	}
+	assert.Contains(t, remainingWorkflowIDs, "feedback")
+	assert.Contains(t, remainingWorkflowIDs, "createannouncement")
+	assert.NotContains(t, remainingWorkflowIDs, "activity")
+}
+
+func TestResetTestsCommandMissingFiles(t *testing.T) {
+	// Create a temporary directory without the files
+	tempDir := t.TempDir()
+
+	// Change to temp directory
+	originalDir, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, os.Chdir(originalDir))
+	}()
+	err = os.Chdir(tempDir)
+	require.NoError(t, err)
+
+	// Set up the command
+	operationIDs = []string{"activity"}
+
+	// Run the delete tests command - should not error when files don't exist
+	err = runResetTests(resetTestsCmd, []string{})
+	require.NoError(t, err)
+}
+
+func TestResetTestsCommandNoOperationIDs(t *testing.T) {
+	// Set up the command with empty operation IDs
+	operationIDs = []string{}
+
+	// Run the delete tests command - should error
+	err := runResetTests(resetTestsCmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one operation ID must be specified")
+}


### PR DESCRIPTION
Add new `reset-tests` command that removes test entries from `gen.lock` and `test.arazzo.yaml` files for specified operation IDs. This allows users to reset generated test files so they can be regenerated with updated requirements from upstream OpenAPI specs.

- Supports multiple operation IDs via `--operation-id` flag
- Processes both `.speakeasy/gen.lock` and `.speakeasy/test.arazzo.yaml` files