### PR TITLE
fix(reset-tests): Use the correct file name (tests.arazzo.yaml)

### DIFF
--- a/cmd/reset_tests.go
+++ b/cmd/reset_tests.go
@@ -28,7 +28,7 @@ type ArazzoWorkflow struct {
 	ExtraData map[string]interface{} `yaml:",inline"`
 }
 
-// ArazzoFile represents the structure of the test.arazzo.yaml file
+// ArazzoFile represents the structure of the tests.arazzo.yaml file
 type ArazzoFile struct {
 	Arazzo             string                   `yaml:"arazzo"`
 	Info               map[string]interface{}   `yaml:"info"`
@@ -39,7 +39,7 @@ type ArazzoFile struct {
 var resetTestsCmd = &cobra.Command{
 	Use:   "reset-tests",
 	Short: "Reset test entries for specified operation IDs",
-	Long: `Delete test entries from both gen.lock and test.arazzo.yaml files
+	Long: `Delete test entries from both gen.lock and tests.arazzo.yaml files
 for the specified operation IDs. This is helpful to allow a subsequent
 'speakeasy run' to regenerate the test files (e.g. if you have new fields /
 equirements in your upstream OpenAPI spec)`,
@@ -71,10 +71,10 @@ func runResetTests(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to process gen.lock: %w", err)
 	}
 
-	// Process test.arazzo.yaml file
-	arazzoPath := ".speakeasy/test.arazzo.yaml"
+	// Process tests.arazzo.yaml file
+	arazzoPath := ".speakeasy/tests.arazzo.yaml"
 	if err := processArazzoFile(arazzoPath, operationIDSet); err != nil {
-		return fmt.Errorf("failed to process test.arazzo.yaml: %w", err)
+		return fmt.Errorf("failed to process tests.arazzo.yaml: %w", err)
 	}
 
 	fmt.Printf("Successfully deleted test entries for operation IDs: %v\n", operationIDs)

--- a/cmd/reset_tests_test.go
+++ b/cmd/reset_tests_test.go
@@ -79,7 +79,7 @@ workflows:
           - condition: $statusCode == 200
     x-speakeasy-test-group: client_feedback
 `
-	err = os.WriteFile(filepath.Join(speakeasyDir, "test.arazzo.yaml"), []byte(arazzoContent), 0o644)
+	err = os.WriteFile(filepath.Join(speakeasyDir, "tests.arazzo.yaml"), []byte(arazzoContent), 0o644)
 	require.NoError(t, err)
 
 	// Set up the command with operation IDs to delete
@@ -105,7 +105,7 @@ workflows:
 	assert.Contains(t, updatedGenLock.GeneratedTests, "getannouncement")
 
 	// Verify arazzo file was updated correctly
-	arazzoData, err := os.ReadFile(filepath.Join(speakeasyDir, "test.arazzo.yaml"))
+	arazzoData, err := os.ReadFile(filepath.Join(speakeasyDir, "tests.arazzo.yaml"))
 	require.NoError(t, err)
 
 	var updatedArazzo map[string]interface{}
@@ -163,7 +163,7 @@ workflows:
       - stepId: test
         operationId: createannouncement
 `
-	err = os.WriteFile(filepath.Join(speakeasyDir, "test.arazzo.yaml"), []byte(arazzoContent), 0o644)
+	err = os.WriteFile(filepath.Join(speakeasyDir, "tests.arazzo.yaml"), []byte(arazzoContent), 0o644)
 	require.NoError(t, err)
 
 	// Set up the command with only one operation ID to delete
@@ -188,7 +188,7 @@ workflows:
 	assert.Contains(t, updatedGenLock.GeneratedTests, "createannouncement")
 
 	// Verify arazzo file was updated correctly
-	arazzoData, err := os.ReadFile(filepath.Join(speakeasyDir, "test.arazzo.yaml"))
+	arazzoData, err := os.ReadFile(filepath.Join(speakeasyDir, "tests.arazzo.yaml"))
 	require.NoError(t, err)
 
 	var updatedArazzo map[string]interface{}


### PR DESCRIPTION
The actual file name is `tests.arazzo.yaml` (not `test.arazzo.yaml`). Update all references to use the plural form 'tests.arazzo.yaml' instead of 'test.arazzo.yaml' in comments, file paths, and error messages.